### PR TITLE
Add the ability to drain a lobby's rooms gracefully

### DIFF
--- a/src/conformance/common.ts
+++ b/src/conformance/common.ts
@@ -1,0 +1,136 @@
+import { RecognizedString } from 'uWebSockets.js';
+import { NT } from '@noita-together/nt-message';
+import { createJwtFns } from '../jwt';
+import { AuthProvider, ClientAuth } from '../runtypes/client_auth';
+import { LobbyState } from '../state/lobby';
+import { BindPublishers } from '../util';
+import { ClientAuthWebSocket, TaggedClientAuth, createMessageHandler } from '../ws_handlers';
+
+export type MockSentMessage = {
+  topic: string | null;
+  user: ClientAuthWebSocket | null;
+  message: NT.Envelope;
+};
+
+export const createTestEnv = (
+  devMode: boolean,
+  createRoomId?: () => string,
+  createChatId?: () => string,
+  createStatsId?: () => string,
+) => {
+  const debug = () => {};
+
+  const sentMessages: MockSentMessage[] = [];
+  const closedSockets: { socket: ClientAuthWebSocket; code?: number; shortMessage?: RecognizedString }[] = [];
+  const subscribed: Map<ClientAuthWebSocket, Set<string>> = new Map();
+
+  const expectLobbyAction = <K extends keyof NT.ILobbyAction>(key: K) => {
+    const env = sentMessages.shift()?.message!;
+    expect(env).toBeDefined();
+    const la = env.lobbyAction! as NT.LobbyAction;
+    expect(la).toBeDefined();
+    expect(la.action).toEqual(key);
+    expect(la[key]).not.toBeUndefined();
+    expect(la[key]).not.toBeNull();
+    return la[key] as Exclude<(typeof la)[K], undefined | null>;
+  };
+  const expectGameAction = <K extends keyof NT.IGameAction>(key: K) => {
+    const env = sentMessages.shift()?.message!;
+    expect(env).toBeDefined();
+    const ga = env.gameAction! as NT.GameAction;
+    expect(ga).toBeDefined();
+    expect(ga.action).toEqual(key);
+    expect(ga[key]).not.toBeUndefined();
+    expect(ga[key]).not.toBeNull();
+    return ga[key] as Exclude<(typeof ga)[K], undefined | null>;
+  };
+
+  const publishers = BindPublishers(
+    {
+      publish: (topic: string, message: Uint8Array | NT.Envelope) => {
+        const decoded = message instanceof Uint8Array ? NT.Envelope.decode(message) : message;
+        sentMessages.push({ topic, message: decoded, user: null });
+      },
+    } as any,
+    createChatId,
+  );
+
+  const lobby = new LobbyState(publishers, devMode, createRoomId, createChatId, createStatsId);
+
+  const { signToken, verifyToken } = createJwtFns('test secret', 'test refresh');
+
+  const { users, sockets, handleUpgrade, handleOpen, handleMessage, handleClose } = createMessageHandler({
+    verifyToken,
+    lobby,
+    debug: debug as any,
+  });
+
+  const testUser = (userId: string, username: string): ClientAuth => ({
+    exp: 0,
+    iat: 0,
+    sub: userId,
+    preferred_username: username,
+    profile_image_url: '',
+    provider: AuthProvider.Twitch,
+  });
+
+  const testToken = (userId: string, username: string) => signToken(userId, testUser(userId, username));
+
+  const testSocket = (userId: string, username: string) => {
+    const clientAuth = testUser(userId, username);
+
+    const user: ClientAuthWebSocket & { toJSON: () => any; toString: () => string } = {
+      send(msg: Uint8Array): number {
+        sentMessages.push({ topic: null, message: NT.Envelope.decode(msg), user });
+        return 1;
+      },
+      getUserData(): TaggedClientAuth {
+        return { conn_id: 0, ...clientAuth };
+      },
+      end(code?: number, shortMessage?: RecognizedString) {
+        closedSockets.push({ socket: user, code, shortMessage });
+      },
+      close() {
+        closedSockets.push({ socket: user });
+      },
+      publish(topic: string, msg: Uint8Array) {
+        sentMessages.push({ topic, message: NT.Envelope.decode(msg), user });
+        return true;
+      },
+      subscribe(topic: string) {
+        const myTopics = subscribed.get(user) ?? new Set();
+        myTopics.add(topic);
+        subscribed.set(user, myTopics);
+        return true;
+      },
+      unsubscribe(topic: string) {
+        const myTopics = subscribed.get(user) ?? new Set();
+        const res = myTopics.delete(topic);
+        subscribed.set(user, myTopics);
+        return res;
+      },
+      toJSON() {
+        return { userId, username };
+      },
+      toString() {
+        return `${userId}:${username}`;
+      },
+    };
+    return user;
+  };
+
+  return {
+    sentMessages,
+    closedSockets,
+    subscribed,
+    lobby,
+    users,
+    expectGameAction,
+    expectLobbyAction,
+    testSocket,
+    handleUpgrade,
+    handleOpen,
+    handleMessage,
+    handleClose,
+  };
+};

--- a/src/conformance/drain.test.ts
+++ b/src/conformance/drain.test.ts
@@ -1,0 +1,214 @@
+import { M } from '@noita-together/nt-message';
+import { createTestEnv } from './common';
+
+const flushPromises = () => new Promise(jest.requireActual('timers').setImmediate);
+
+describe('server drain', () => {
+  it('resolves immediately with no connected users', async () => {
+    jest.useFakeTimers();
+
+    const { lobby } = createTestEnv(false);
+
+    const cb = jest.fn();
+    lobby.drain(2).then(cb);
+
+    jest.advanceTimersByTime(1);
+    await flushPromises();
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+  it('resolves immediately with users connected but no open rooms', async () => {
+    jest.useFakeTimers();
+
+    const { testSocket, handleOpen, lobby } = createTestEnv(false);
+    const user = testSocket('id', 'name');
+    handleOpen(user);
+
+    const cb = jest.fn();
+    lobby.drain(2).then(cb);
+
+    jest.advanceTimersByTime(1);
+    await flushPromises();
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+  it('resolves after the drop-dead time with open rooms that are still in a run', async () => {
+    jest.useFakeTimers();
+
+    const { testSocket, handleOpen, handleMessage, lobby } = createTestEnv(false);
+    const user = testSocket('id', 'name');
+    handleOpen(user);
+    handleMessage(user, M.cRoomCreate({ gamemode: 0, maxUsers: 5, name: "name's room" }, true), true);
+    handleMessage(user, M.cStartRun({}, true), true);
+
+    const cb = jest.fn();
+    lobby.drain(2).then(cb);
+
+    jest.advanceTimersByTime(1);
+    await flushPromises();
+    expect(cb).toHaveBeenCalledTimes(0);
+
+    jest.advanceTimersByTime(1);
+    await flushPromises();
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+  it('resolves after the drop-dead time with open rooms that ARE actively in a run when the run ends', async () => {
+    jest.useFakeTimers();
+
+    const { testSocket, handleOpen, handleMessage, lobby } = createTestEnv(false);
+    const user = testSocket('id', 'name');
+    handleOpen(user);
+    handleMessage(user, M.cRoomCreate({ gamemode: 0, maxUsers: 5, name: "name's room" }, true), true);
+    handleMessage(user, M.cStartRun({}, true), true);
+
+    const cb = jest.fn();
+    lobby.drain(2).then(cb);
+
+    jest.advanceTimersByTime(1);
+    await flushPromises();
+    expect(cb).toHaveBeenCalledTimes(0);
+
+    handleMessage(user, M.cRunOver({}, true), true);
+
+    jest.advanceTimersByTime(1);
+    await flushPromises();
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+  // when drop-dead time is later than the 5-minute run-end timeout
+  it('resolves after the 5-minute timeout with open rooms that ARE actively in a run when the run ends', async () => {
+    jest.useFakeTimers();
+
+    const { testSocket, handleOpen, handleMessage, lobby } = createTestEnv(false);
+    const user = testSocket('id', 'name');
+    handleOpen(user);
+    handleMessage(user, M.cRoomCreate({ gamemode: 0, maxUsers: 5, name: "name's room" }, true), true);
+    handleMessage(user, M.cStartRun({}, true), true);
+
+    const cb = jest.fn();
+    lobby.drain(10 * 60 * 1000).then(cb);
+
+    await flushPromises();
+
+    handleMessage(user, M.cRunOver({}, true), true);
+
+    jest.advanceTimersByTime(5 * 60 * 1000 - 1);
+    await flushPromises();
+    expect(cb).toHaveBeenCalledTimes(0);
+
+    jest.advanceTimersByTime(1);
+    await flushPromises();
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+  it('prevents creation of new rooms when draining', async () => {
+    const { testSocket, handleOpen, handleMessage, lobby, expectLobbyAction } = createTestEnv(false);
+
+    lobby.drain(2);
+    jest.advanceTimersByTime(10);
+    await flushPromises();
+
+    const user = testSocket('id', 'name');
+    handleOpen(user);
+    handleMessage(user, M.cRoomCreate({ gamemode: 0, maxUsers: 5, name: "name's room" }, true), true);
+
+    const sRoomCreated = expectLobbyAction('sRoomCreateFailed');
+    expect(sRoomCreated.reason).toMatch(/shutting down/i);
+  });
+  it('prevents starting new runs when draining', async () => {
+    const { testSocket, handleOpen, handleMessage, lobby, sentMessages, expectGameAction, expectLobbyAction } =
+      createTestEnv(false);
+    const user = testSocket('id', 'name');
+    handleOpen(user);
+    handleMessage(user, M.cRoomCreate({ gamemode: 0, maxUsers: 5, name: "name's room" }, true), true);
+    expectLobbyAction('sRoomCreated');
+    expectLobbyAction('sRoomAddToList');
+
+    lobby.drain(2);
+
+    jest.advanceTimersByTime(1);
+    await flushPromises();
+
+    const chat1 = expectGameAction('sChat');
+    expect(chat1.message).toMatch(/will shut down/i);
+
+    handleMessage(user, M.cStartRun({}, true), true);
+
+    jest.advanceTimersByTime(1);
+    await flushPromises();
+
+    const chat2 = expectGameAction('sChat');
+    expect(chat2.message).toMatch(/shutting down/i);
+
+    // there is no response to cStartRun - so it is not expected to be able to fail
+    // since we can't check for a failure response, we'll instead ensure no "start game" message was sent
+    expect(sentMessages).toEqual([]);
+  });
+  it('notifies rooms immediately of a pending shutdown', async () => {
+    jest.useFakeTimers();
+
+    const { testSocket, handleOpen, handleMessage, lobby, sentMessages, expectGameAction, expectLobbyAction } =
+      createTestEnv(false);
+    const user = testSocket('id', 'name');
+
+    handleOpen(user);
+    handleMessage(user, M.cRoomCreate({ gamemode: 0, maxUsers: 5, name: "name's room" }, true), true);
+    handleMessage(user, M.cStartRun({}, true), true);
+
+    expectLobbyAction('sRoomCreated');
+    expectLobbyAction('sRoomAddToList');
+    expectLobbyAction('sHostStart');
+
+    lobby.drain(10 * 60 * 1000);
+
+    jest.advanceTimersByTime(1);
+    await flushPromises();
+
+    const chat1 = expectGameAction('sChat');
+    expect(chat1.message).toMatch(/will shut down/i);
+
+    jest.advanceTimersByTime(60 * 1000 - 2);
+    await flushPromises();
+    expect(sentMessages).toEqual([]);
+
+    jest.advanceTimersByTime(1);
+    await flushPromises();
+
+    const chat2 = expectGameAction('sChat');
+    expect(chat2.message).toMatch(/will shut down/i);
+  });
+  it('notifies rooms immediately of a pending shutdown', async () => {
+    jest.useFakeTimers();
+
+    const { testSocket, handleOpen, handleMessage, lobby, sentMessages, expectGameAction, expectLobbyAction } =
+      createTestEnv(false);
+    const user = testSocket('id', 'name');
+
+    handleOpen(user);
+    handleMessage(user, M.cRoomCreate({ gamemode: 0, maxUsers: 5, name: "name's room" }, true), true);
+    handleMessage(user, M.cStartRun({}, true), true);
+
+    expectLobbyAction('sRoomCreated');
+    expectLobbyAction('sRoomAddToList');
+    expectLobbyAction('sHostStart');
+
+    lobby.drain(10 * 60 * 1000);
+
+    jest.advanceTimersByTime(1);
+    await flushPromises();
+
+    // initial broadcast notification
+    const chat1 = expectGameAction('sChat');
+    expect(chat1.message).toMatch(/will shut down/i);
+
+    handleMessage(user, M.cRunOver({}, true), true);
+
+    jest.advanceTimersByTime(1);
+    await flushPromises();
+
+    // run-over stats message (optional)
+    const chat2 = (() => {
+      const maybeStatsChat = expectGameAction('sChat');
+      if (!/stats for run/i.test(maybeStatsChat.message ?? '')) return maybeStatsChat;
+      return expectGameAction('sChat');
+    })();
+
+    expect(chat2.message).toMatch(/shutting down/i);
+  });
+});

--- a/src/conformance/lobby.test.ts
+++ b/src/conformance/lobby.test.ts
@@ -1,139 +1,7 @@
-import { RecognizedString } from 'uWebSockets.js';
 import { M, NT } from '@noita-together/nt-message';
-import { createJwtFns } from '../jwt';
-import { AuthProvider, ClientAuth } from '../runtypes/client_auth';
-import { LobbyState, SYSTEM_USER } from '../state/lobby';
-import { BindPublishers } from '../util';
-import { ClientAuthWebSocket, TaggedClientAuth, createMessageHandler } from '../ws_handlers';
-
-type sentMessage = {
-  topic: string | null;
-  user: ClientAuthWebSocket | null;
-  message: NT.Envelope;
-};
-
-const createTestEnv = (
-  devMode: boolean,
-  createRoomId?: () => string,
-  createChatId?: () => string,
-  createStatsId?: () => string,
-) => {
-  const debug = () => {};
-
-  const sentMessages: sentMessage[] = [];
-  const closedSockets: { socket: ClientAuthWebSocket; code?: number; shortMessage?: RecognizedString }[] = [];
-  const subscribed: Map<ClientAuthWebSocket, Set<string>> = new Map();
-
-  const expectLobbyAction = <K extends keyof NT.ILobbyAction>(key: K) => {
-    const env = sentMessages.shift()?.message!;
-    expect(env).toBeDefined();
-    const la = env.lobbyAction! as NT.LobbyAction;
-    expect(la).toBeDefined();
-    expect(la.action).toEqual(key);
-    expect(la[key]).not.toBeUndefined();
-    expect(la[key]).not.toBeNull();
-    return la[key] as Exclude<(typeof la)[K], undefined | null>;
-  };
-  const expectGameAction = <K extends keyof NT.IGameAction>(key: K) => {
-    const env = sentMessages.shift()?.message!;
-    expect(env).toBeDefined();
-    const ga = env.gameAction! as NT.GameAction;
-    expect(ga).toBeDefined();
-    expect(ga.action).toEqual(key);
-    expect(ga[key]).not.toBeUndefined();
-    expect(ga[key]).not.toBeNull();
-    return ga[key] as Exclude<(typeof ga)[K], undefined | null>;
-  };
-
-  const publishers = BindPublishers(
-    {
-      publish: (topic: string, message: Uint8Array | NT.Envelope) => {
-        const decoded = message instanceof Uint8Array ? NT.Envelope.decode(message) : message;
-        sentMessages.push({ topic, message: decoded, user: null });
-      },
-    } as any,
-    createChatId,
-  );
-
-  const lobby = new LobbyState(publishers, devMode, createRoomId, createChatId, createStatsId);
-
-  const { signToken, verifyToken } = createJwtFns('test secret', 'test refresh');
-
-  const { users, sockets, handleUpgrade, handleOpen, handleMessage, handleClose } = createMessageHandler({
-    verifyToken,
-    lobby,
-    debug: debug as any,
-  });
-
-  const testUser = (userId: string, username: string): ClientAuth => ({
-    exp: 0,
-    iat: 0,
-    sub: userId,
-    preferred_username: username,
-    profile_image_url: '',
-    provider: AuthProvider.Twitch,
-  });
-
-  const testToken = (userId: string, username: string) => signToken(userId, testUser(userId, username));
-
-  const testSocket = (userId: string, username: string) => {
-    const clientAuth = testUser(userId, username);
-
-    const user: ClientAuthWebSocket & { toJSON: () => any; toString: () => string } = {
-      send(msg: Uint8Array): number {
-        sentMessages.push({ topic: null, message: NT.Envelope.decode(msg), user });
-        return 1;
-      },
-      getUserData(): TaggedClientAuth {
-        return { conn_id: 0, ...clientAuth };
-      },
-      end(code?: number, shortMessage?: RecognizedString) {
-        closedSockets.push({ socket: user, code, shortMessage });
-      },
-      close() {
-        closedSockets.push({ socket: user });
-      },
-      publish(topic: string, msg: Uint8Array) {
-        sentMessages.push({ topic, message: NT.Envelope.decode(msg), user });
-        return true;
-      },
-      subscribe(topic: string) {
-        const myTopics = subscribed.get(user) ?? new Set();
-        myTopics.add(topic);
-        subscribed.set(user, myTopics);
-        return true;
-      },
-      unsubscribe(topic: string) {
-        const myTopics = subscribed.get(user) ?? new Set();
-        const res = myTopics.delete(topic);
-        subscribed.set(user, myTopics);
-        return res;
-      },
-      toJSON() {
-        return { userId, username };
-      },
-      toString() {
-        return `${userId}:${username}`;
-      },
-    };
-    return user;
-  };
-
-  return {
-    sentMessages,
-    closedSockets,
-    subscribed,
-    lobby,
-    users,
-    expectGameAction,
-    expectLobbyAction,
-    testSocket,
-    handleUpgrade,
-    handleOpen,
-    handleMessage,
-    handleClose,
-  };
-};
+import { SYSTEM_USER } from '../state/lobby';
+import { ClientAuthWebSocket } from '../ws_handlers';
+import { createTestEnv, MockSentMessage } from './common';
 
 const uuidRE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
@@ -506,7 +374,7 @@ describe('lobby conformance tests', () => {
     type test = {
       name: string;
       clientMessages: (users: Record<string, ClientAuthWebSocket>) => clientMessage[];
-      serverMessages: (users: Record<string, ClientAuthWebSocket>) => sentMessage[];
+      serverMessages: (users: Record<string, ClientAuthWebSocket>) => MockSentMessage[];
     };
 
     const t = (

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,3 +137,6 @@ if (APP_UNIX_SOCKET) {
 
 process.on('SIGTERM', shutdown);
 process.on('SIGINT', shutdown);
+process.on('SIGQUIT', () => {
+  lobby.drain(60 * 60 * 1000).then(shutdown);
+});

--- a/src/util.ts
+++ b/src/util.ts
@@ -61,3 +61,34 @@ export const shortHash = (() => {
   const key = randomBytes(256 / 8);
   return (ip: string): string => createHmac('sha256', key).update(ip).digest().subarray(0, 12).toString('base64');
 })();
+
+export const makeDeferred = (cb?: () => void) => {
+  const deferred: {
+    resolve: (value: void | PromiseLike<void>) => void;
+    reject: (reason?: any) => void;
+    promise: Promise<void>;
+  } = {} as any;
+  deferred.promise = new Promise<void>((resolve, reject) => {
+    deferred.resolve = resolve;
+    deferred.reject = reject;
+  }).then(cb);
+  return deferred;
+};
+export type Deferred = ReturnType<typeof makeDeferred>;
+
+export const formatDuration = (durationMs: number) => {
+  const units = [
+    // { label: 'year', seconds: 31_536_000_000 },
+    // { label: 'month', seconds: 2_592_000_000 },
+    // { label: 'day', seconds: 86_400_000 },
+    { label: 'hour', seconds: 3_600_000 },
+    { label: 'minute', seconds: 60_000 },
+    // { label: 'second', seconds: 1_000 },
+  ];
+
+  for (const unit of units) {
+    const unitCount = Math.round(durationMs / unit.seconds);
+    if (unitCount > 0) return `${unitCount} ${unit.label}${unitCount > 1 ? 's' : ''}`;
+  }
+  return 'a moment';
+};


### PR DESCRIPTION
## What
Adds a SIGQUIT handler and associated code to put the lobby server into a "drain" mode, where it will reject new rooms and new runs, notify users to finish up and reload the NT app, and eventually terminate everything.

## Why
We have enough active users now that we can't just wait for the server to be empty to upgrade the code without interrupting runs. This is a step towards being able to deploy a container with the new code (which will receive new incoming connections), while allowing the old container to continue running and servicing any in-progress runs.

## How
Currently unconfigurable, but the behavior is as follows:
- lobby.drain() is called on SIGQUIT with a drop-dead time of 60 minutes
- any open rooms will receive a shutdown message immediately and every minute thereafter
- rooms that are actively in a run will be destroyed after 1 hour or 5 minutes after the run ends, whichever comes first
- rooms that are NOT in a run will be destroyed after 5 minutes (if not destroyed sooner, e.g. by the users leaving)
- when all rooms are destroyed, the process will exit (disconnecting any remaining sockets in the process)
- in drain mode, new rooms cannot be created and new runs cannot be started

## Notes
- TODO: at the ops level, we are probably going to need to go back to using a reverse proxy (nginx?) for the websockets. I think this will be okay for the following reasons:
- The lobby server is currently single-threaded, so we have a spare core's worth of headroom
- Multi-threading the app (if we get to that point) is probably better-handled by exploring porting the lobby server to Cloudflare workers
- It appears to be possible to specify (at the Docker level) which cores a container may use: https://stackoverflow.com/a/25999490

This suggests that we could devote one core to the lobby server and another core to Nginx, preventing nginx from "cutting into" the CPU available to the lobby server. At that point, it doesn't matter too much if the nginx workers take as much cpu as the lobby server does.

If it comes about that we are running out of CPU capacity, we can either:
- Scale up the server
  - Some code change will be required to take advantage of more than one core for running the lobby server itself. With uWebSockets, and running on Linux, it's possible to listen on the same port from multiple threads (or processes?) - but which thread receives a websocket connection will be random. We'll need a parent thread so that the child thread (which received and processed a message) can broadcast to websockets owned by the other thread.
  - With that change in place, we could conceivably assign 2 cores to the lobby server and 2 cores to nginx, etc.
- Explore Cloudflare Workers: with "Durable Objects", we could encapsulate all the relevant code into the "RoomState" abstraction, and have an instance of a durable object per room. This would solve all our scaling needs but require some changes to the code's architecture. Graceful upgrade / blue-green deploy are possibilities with a load balancer, but we could change the protocol so that the "lobby" is one websocket connection that instructs the NT app to connect to the "room" on a separate websocket. Then, a changeover is enacted by telling the lobby which backend to send players to. In this world, rather than multiplexing everything over a single websocket, we will much more frequently establish new websockets - which is probably a good thing for scale and resiliency.
  - I have no idea how to determine if this would be cheaper or more expensive, or how to limit costs (in terms of dollars). However, since the lobby server is mostly message-passing, and the networking is handled by Cloudflare and not the app itself, we don't pay "active running application time" for messages being sent over the network - which could be a big win