### PR TITLE
Build images on PRs to `next`

### DIFF
--- a/.github/workflows/build-deploy-pr-image.yml
+++ b/.github/workflows/build-deploy-pr-image.yml
@@ -1,0 +1,44 @@
+name: Docker Image CI
+
+on:
+  pull_request:
+    branches: [next]
+    types: [opened, synchronize, reopened]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: pr-${{ github.event.number }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/build-deploy-pr-image.yml
+++ b/.github/workflows/build-deploy-pr-image.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: pr-${{ github.event.number }}
+          tags: ${{env.REGISTRY}}/${{env.IMAGE_NAME}}:pr-${{ github.event.number }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ ARG UWS_TARGET_LIB=uws_linux_x64_120.node
 RUN find 'node_modules/uWebSockets.js' -name '*.node' -not -name "$UWS_TARGET_LIB" -delete
 
 FROM node:21-slim
+LABEL org.opencontainers.image.source https://github.com/noita-together/lobby-server
 
 ARG UID=0
 ARG GID=0


### PR DESCRIPTION
Testing using GHCR to host images so that we can deploy development artifacts without actually building on the server