### PR TITLE
Allow configuring the ip/interface to which Docker will bind

### DIFF
--- a/deploy/restart.sh
+++ b/deploy/restart.sh
@@ -81,7 +81,7 @@ if [ $# -eq 0 ]; then
   RUN_ARGS=(
     -d --name "$CONTAINER_NAME"
     --restart "unless-stopped"
-    -p "$BACKEND_PORT:${APP_LISTEN_PORT:-4444}" \
+    -p "${DOCKER_BIND_IP:-0.0.0.0}:$BACKEND_PORT:${APP_LISTEN_PORT:-4444}" \
   )
   docker stop "$CONTAINER_NAME" || true
   docker rm "$CONTAINER_NAME" || true


### PR DESCRIPTION
I've set up a HAProxy server in the same datacenter on a private network interface. Because of this, SSL is no longer really required for the lobby-server container, so long as we only listen on the private interface, but there was no environment variable to configure this. This allows overriding it from Docker's default of 0.0.0.0

